### PR TITLE
remove inline svg style, Making SVGs Responsive with CSS

### DIFF
--- a/lib/plantumlRender.js
+++ b/lib/plantumlRender.js
@@ -144,7 +144,12 @@ function serverSideRendering(config, str) {
                         } else if (config.link === "inlineUrlEncode") {
                             resolve(`<img class="${config.className}" src='data:image/svg+xml;utf8,${encodeURIComponent(buffer.toString())}'>`);
                         } else {
-                            resolve(buffer.toString().replace(/<svg(.*?)>/g, `<svg $1 class="${config.className}">$2`))
+                            // remove inline svg style
+                            const svg = buffer.toString()
+                                .replace(/(<svg.*?)width=".*?"(.*?>)/g, '$1$2')
+                                .replace(/(<svg.*?)height=".*?"(.*?>)/g, '$1$2')
+                                .replace(/(<svg.*?)style=".*?"(.*?>)/g, '$1$2');
+                            resolve(`<div class="${config.className}">${svg}</div>`);
                         }
                     });
                 });


### PR DESCRIPTION
移除内联svg的样式，让svg内容响应式适应css的样式。

ref: https://tympanus.net/Tutorials/ResponsiveSVGs/index4.html